### PR TITLE
提取核心逻辑到 mixtex_core 并新增使用示例

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,175 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# PyPI configuration file
+.pypirc
+
+mixtexgui/dist
+mixtexgui/build
+onnx/

--- a/mixtexgui/examples/example.py
+++ b/mixtexgui/examples/example.py
@@ -1,0 +1,19 @@
+from mixtex_core import (
+    load_model,
+    pad_image,
+    stream_inference,
+    # convert_align_to_equations,
+)
+from PIL import Image
+
+if __name__ == "__main__":
+    model = load_model("onnx")
+    img = Image.open("test.png").convert("RGB")
+    img_padded = pad_image(img)
+    partial_result = []
+    for piece in stream_inference(img_padded, model):
+        print(piece, end="", flush=True)  # 流式输出
+        partial_result.append(piece)
+
+    # result_text = convert_align_to_equations("".join(partial_result))
+    # print("\n最终结果:\n", result_text)

--- a/mixtexgui/examples/example_streamlit.py
+++ b/mixtexgui/examples/example_streamlit.py
@@ -1,0 +1,47 @@
+from mixtex_core import (
+    load_model,
+    pad_image,
+    stream_inference,
+    # convert_align_to_equations,
+)
+from PIL import Image
+
+import streamlit as st
+from PIL import ImageGrab
+
+
+def main():
+    st.set_page_config(page_title="MixTeX LaTeX OCR", page_icon="../icon.ico")
+    st.title("MixTeX LaTeX OCR")
+    model = load_model("onnx")
+
+    uploaded_file = st.file_uploader("选择图片文件", type=["png", "jpg", "jpeg"])
+
+    if st.button("从剪贴板粘贴图片"):
+        try:
+            img = ImageGrab.grabclipboard()
+            if img:
+                st.image(img, caption="剪贴板图片预览")
+                run_inference(model, img)
+            else:
+                st.warning("剪贴板没有可用图片")
+        except Exception as e:
+            st.error(str(e))
+
+    if uploaded_file:
+        img = Image.open(uploaded_file).convert("RGB")
+        st.image(img, caption="上传图片预览")
+        run_inference(model, img)
+
+
+def run_inference(model, img):
+    img_padded = pad_image(img)
+    partial_result = ""
+    output_area = st.empty()
+    for piece in stream_inference(img_padded, model):
+        partial_result += piece
+        output_area.code(partial_result, language="latex")
+
+
+if __name__ == "__main__":
+    main()

--- a/mixtexgui/examples/mixtex_core.py
+++ b/mixtexgui/examples/mixtex_core.py
@@ -1,0 +1,86 @@
+import onnxruntime as ort
+import numpy as np
+from PIL import Image
+import re
+from transformers import AutoTokenizer, AutoImageProcessor
+
+
+def load_model(model_dir):
+    tokenizer = AutoTokenizer.from_pretrained(model_dir)
+    feature_extractor = AutoImageProcessor.from_pretrained(model_dir)
+    encoder_sess = ort.InferenceSession(f"{model_dir}/encoder_model.onnx")
+    decoder_sess = ort.InferenceSession(f"{model_dir}/decoder_model_merged.onnx")
+    return tokenizer, feature_extractor, encoder_sess, decoder_sess
+
+
+def pad_image(img, out_size=(448, 448)):
+    x_img, y_img = out_size
+    bg = Image.new("RGB", (x_img, y_img), (255, 255, 255))
+    w, h = img.size
+    if w < x_img and h < y_img:
+        x = (x_img - w) // 2
+        y = (y_img - h) // 2
+        bg.paste(img, (x, y))
+    else:
+        scale = min(x_img / w, y_img / h)
+        nw, nh = int(w * scale), int(h * scale)
+        img_resized = img.resize((nw, nh), Image.LANCZOS)
+        x = (x_img - nw) // 2
+        y = (y_img - nh) // 2
+        bg.paste(img_resized, (x, y))
+    return bg
+
+
+def check_repetition(s, repeats=12):
+    for pattern_length in range(1, len(s) // repeats + 1):
+        for start in range(len(s) - repeats * pattern_length + 1):
+            pattern = s[start : start + pattern_length]
+            if s[start : start + repeats * pattern_length] == pattern * repeats:
+                return True
+    return False
+
+
+def convert_align_to_equations(text):
+    text = re.sub(r"\\begin\{align\*\}|\\end\{align\*\}", "", text).replace("&", "")
+    eqs = text.strip().split("\\\\")
+    return "\n".join(f"$$ {eq.strip()} $$" for eq in eqs if eq.strip())
+
+
+def stream_inference(
+    image, model, max_length=512, num_layers=3, hidden_size=768, heads=12, batch_size=1
+):
+    tokenizer, feature_extractor, enc_session, dec_session = model
+    head_size = hidden_size // heads
+    inputs = feature_extractor(image, return_tensors="np").pixel_values
+    enc_out = enc_session.run(None, {"pixel_values": inputs})[0]
+    dec_in = {
+        "input_ids": tokenizer("<s>", return_tensors="np").input_ids.astype(np.int64),
+        "encoder_hidden_states": enc_out,
+        "use_cache_branch": np.array([True], dtype=bool),
+        **{
+            f"past_key_values.{i}.{t}": np.zeros(
+                (batch_size, heads, 0, head_size), dtype=np.float32
+            )
+            for i in range(num_layers)
+            for t in ["key", "value"]
+        },
+    }
+    generated = ""
+    for _ in range(max_length):
+        outs = dec_session.run(None, dec_in)
+        next_id = np.argmax(outs[0][:, -1, :], axis=-1)
+        token_text = tokenizer.decode(next_id, skip_special_tokens=True)
+        yield token_text  # 流式输出
+        generated += token_text
+        if check_repetition(generated, 21) or next_id == tokenizer.eos_token_id:
+            break
+        dec_in.update(
+            {
+                "input_ids": next_id[:, None],
+                **{
+                    f"past_key_values.{i}.{t}": outs[i * 2 + 1 + j]
+                    for i in range(num_layers)
+                    for j, t in enumerate(["key", "value"])
+                },
+            }
+        )


### PR DESCRIPTION
将 `mixtex_ui` 中的核心逻辑提取到新的模块 `mixtex_core` 中。  

实现了两个基于 `mixtex_core` 的使用示例：  
  - 代码调用示例：通过代码直接调用 `mixtex_core`
  - Streamlit 示例：基于 Streamlit 实现的交互式应用

